### PR TITLE
chore: bump version to 1.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utfall-parser",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "parse UTF_ALL.csv",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary
`package.json` のバージョンを `1.0.6` → `1.0.7` に更新するリリース PR。

## Changes
- `package.json` の `version` を `1.0.7` に変更